### PR TITLE
fix: make allow/deny directory filter work reliably

### DIFF
--- a/simkl_mps/config_manager.py
+++ b/simkl_mps/config_manager.py
@@ -201,17 +201,25 @@ def load_settings():
 def save_settings(settings_dict):
     """Save settings atomically (temp file + rename) plus a .bak. Returns True on success."""
     global _last_good_settings
+
+    # Sanitize the allow/deny lists before writing and caching, so a partial or malformed
+    # save can't later be handed back by _fallback_settings with the allow-list dropped.
+    to_save = dict(settings_dict) if isinstance(settings_dict, dict) else settings_dict
+    if isinstance(to_save, dict):
+        for key in ("allow_dirs", "deny_dirs"):
+            to_save[key] = _sanitize_dir_list(to_save.get(key))
+
     try:
         SETTINGS_DIR.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         log.error(f"Could not create settings directory {SETTINGS_DIR}: {e}")
         return False
 
-    if not _atomic_write_json(SETTINGS_FILE, settings_dict):
+    if not _atomic_write_json(SETTINGS_FILE, to_save):
         return False
 
-    _last_good_settings = copy.deepcopy(settings_dict)
-    _atomic_write_json(_backup_path(), settings_dict)  # best effort; failure isn't fatal
+    _last_good_settings = copy.deepcopy(to_save)
+    _atomic_write_json(_backup_path(), to_save)  # best effort; failure isn't fatal
     log.info(f"Settings saved successfully to {SETTINGS_FILE}")
     return True
 

--- a/simkl_mps/config_manager.py
+++ b/simkl_mps/config_manager.py
@@ -1,7 +1,9 @@
+import copy
 import json
 import os
 import logging
 import sys
+import time
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -43,6 +45,80 @@ DEFAULT_SETTINGS = {
     "deny_dirs": []
 }
 
+# Last settings read/written OK; fallback so a corrupt read doesn't blank allow_dirs.
+_last_good_settings = None
+
+# Retry the rename: on Windows os.replace fails while another handle holds the file.
+_REPLACE_RETRIES = 5
+_REPLACE_DELAY_SECONDS = 0.1
+
+
+def _backup_path():
+    """Sibling backup file, e.g. settings.json.bak."""
+    return SETTINGS_FILE.with_name(SETTINGS_FILE.name + ".bak")
+
+
+def _remove_quietly(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _atomic_write_json(target_path, settings_dict):
+    """Write JSON to target_path via a temp file + atomic rename. Returns True on success."""
+    tmp_file = target_path.with_name(target_path.name + ".tmp")
+    try:
+        with open(tmp_file, 'w', encoding='utf-8') as f:
+            json.dump(settings_dict, f, indent=4)
+            f.flush()
+            os.fsync(f.fileno())
+    except Exception as e:
+        log.error(f"Could not write temp settings file {tmp_file}: {e}")
+        _remove_quietly(tmp_file)
+        return False
+
+    last_error = None
+    for _ in range(_REPLACE_RETRIES):
+        try:
+            os.replace(tmp_file, target_path)  # atomic rename
+            return True
+        except OSError as e:
+            last_error = e
+            time.sleep(_REPLACE_DELAY_SECONDS)
+    log.error(f"Could not replace {target_path} after {_REPLACE_RETRIES} tries: {last_error}")
+    _remove_quietly(tmp_file)
+    return False
+
+
+def _load_backup():
+    """Parse the backup file, or None if it's missing/unreadable."""
+    try:
+        with open(_backup_path(), 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _fallback_settings():
+    """Settings after a read error: in-memory cache, then .bak, then defaults."""
+    global _last_good_settings
+    if _last_good_settings is not None:
+        log.warning("Falling back to last known good settings after a settings read error.")
+        return copy.deepcopy(_last_good_settings)
+
+    backup = _load_backup()
+    if backup is not None:
+        log.warning("Recovered settings from backup after a settings read error.")
+        merged = DEFAULT_SETTINGS.copy()
+        merged.update(backup)
+        _last_good_settings = copy.deepcopy(merged)
+        return merged
+
+    log.error("No settings backup available; using defaults (allow-list is disabled).")
+    return DEFAULT_SETTINGS.copy()
+
+
 def _sanitize_dir_list(value):
     """Ensure allow/deny dir settings are stored as a list of strings."""
     if value is None:
@@ -70,60 +146,68 @@ def load_settings():
     try:
         with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
             settings = json.load(f)
-            
-            # Ensure all default settings exist, otherwise add them
-            settings_updated = False
-            for key, default_value in DEFAULT_SETTINGS.items():
-                if key not in settings:
-                    settings[key] = default_value
-                    settings_updated = True
-            
-            # Validate threshold value
-            try:
-                current_threshold = int(settings['watch_completion_threshold'])
-                if not (1 <= current_threshold <= 100):
-                    log.warning(f"Invalid watch_completion_threshold '{current_threshold}' in {SETTINGS_FILE}. Resetting to {DEFAULT_THRESHOLD}.")
-                    settings['watch_completion_threshold'] = DEFAULT_THRESHOLD
-                    settings_updated = True
-            except (ValueError, TypeError):
-                 log.warning(f"Non-integer watch_completion_threshold '{settings.get('watch_completion_threshold')}' in {SETTINGS_FILE}. Resetting to {DEFAULT_THRESHOLD}.")
-                 settings['watch_completion_threshold'] = DEFAULT_THRESHOLD
-                 settings_updated = True
-
-            # Sanitize allow/deny directory lists
-            for key in ("allow_dirs", "deny_dirs"):
-                sanitized = _sanitize_dir_list(settings.get(key))
-                if settings.get(key) != sanitized:
-                    settings[key] = sanitized
-                    settings_updated = True
-
-            # Save the file only if defaults were added or invalid values corrected
-            if settings_updated:
-                save_settings(settings)
-                
-            return settings
-    except (json.JSONDecodeError, IOError) as e:
-        log.error(f"Error loading settings from {SETTINGS_FILE}: {e}. Using defaults.")
-        return DEFAULT_SETTINGS.copy()
+    except (json.JSONDecodeError, IOError, OSError) as e:
+        log.error(f"Error loading settings from {SETTINGS_FILE}: {e}. Falling back.")
+        return _fallback_settings()
     except Exception as e:
-        log.error(f"An unexpected error occurred while loading settings: {e}. Using defaults.")
-        return DEFAULT_SETTINGS.copy()
+        log.error(f"An unexpected error occurred while loading settings: {e}. Falling back.")
+        return _fallback_settings()
+
+    # File is closed now; save AFTER this, never inside the read block (Windows can't
+    # rename over a file that's still open -> WinError 5).
+    global _last_good_settings
+
+    # Ensure all default settings exist, otherwise add them
+    settings_updated = False
+    for key, default_value in DEFAULT_SETTINGS.items():
+        if key not in settings:
+            settings[key] = default_value
+            settings_updated = True
+
+    # Validate threshold value
+    try:
+        current_threshold = int(settings['watch_completion_threshold'])
+        if not (1 <= current_threshold <= 100):
+            log.warning(f"Invalid watch_completion_threshold '{current_threshold}' in {SETTINGS_FILE}. Resetting to {DEFAULT_THRESHOLD}.")
+            settings['watch_completion_threshold'] = DEFAULT_THRESHOLD
+            settings_updated = True
+    except (ValueError, TypeError):
+        log.warning(f"Non-integer watch_completion_threshold '{settings.get('watch_completion_threshold')}' in {SETTINGS_FILE}. Resetting to {DEFAULT_THRESHOLD}.")
+        settings['watch_completion_threshold'] = DEFAULT_THRESHOLD
+        settings_updated = True
+
+    # Sanitize allow/deny directory lists
+    for key in ("allow_dirs", "deny_dirs"):
+        sanitized = _sanitize_dir_list(settings.get(key))
+        if settings.get(key) != sanitized:
+            settings[key] = sanitized
+            settings_updated = True
+
+    _last_good_settings = copy.deepcopy(settings)
+
+    # Persist enrichment/corrections only now that the read handle is closed.
+    if settings_updated:
+        save_settings(settings)
+
+    return settings
 
 
 def save_settings(settings_dict):
-    """Saves the provided settings dictionary to the JSON file in the user config directory."""
+    """Save settings atomically (temp file + rename) plus a .bak. Returns True on success."""
+    global _last_good_settings
     try:
-        # Ensure parent directory exists
         SETTINGS_DIR.mkdir(parents=True, exist_ok=True)
-        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
-            json.dump(settings_dict, f, indent=4)
-        log.info(f"Settings saved successfully to {SETTINGS_FILE}")
     except OSError as e:
-         log.error(f"Could not create or write to settings directory/file {SETTINGS_FILE}: {e}")
-    except IOError as e:
-        log.error(f"Error saving settings to {SETTINGS_FILE}: {e}")
-    except Exception as e:
-        log.error(f"An unexpected error occurred while saving settings: {e}")
+        log.error(f"Could not create settings directory {SETTINGS_DIR}: {e}")
+        return False
+
+    if not _atomic_write_json(SETTINGS_FILE, settings_dict):
+        return False
+
+    _last_good_settings = copy.deepcopy(settings_dict)
+    _atomic_write_json(_backup_path(), settings_dict)  # best effort; failure isn't fatal
+    log.info(f"Settings saved successfully to {SETTINGS_FILE}")
+    return True
 
 
 def get_setting(key, default=None):

--- a/simkl_mps/config_manager.py
+++ b/simkl_mps/config_manager.py
@@ -72,7 +72,10 @@ def _atomic_write_json(target_path, settings_dict):
         with open(tmp_file, 'w', encoding='utf-8') as f:
             json.dump(settings_dict, f, indent=4)
             f.flush()
-            os.fsync(f.fileno())
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass  # some filesystems (network/virtual) don't support fsync
     except Exception as e:
         log.error(f"Could not write temp settings file {tmp_file}: {e}")
         _remove_quietly(tmp_file)
@@ -92,10 +95,11 @@ def _atomic_write_json(target_path, settings_dict):
 
 
 def _load_backup():
-    """Parse the backup file, or None if it's missing/unreadable."""
+    """Parse the backup file (must be a dict), or None if missing/unreadable/wrong shape."""
     try:
         with open(_backup_path(), 'r', encoding='utf-8') as f:
-            return json.load(f)
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -110,13 +114,13 @@ def _fallback_settings():
     backup = _load_backup()
     if backup is not None:
         log.warning("Recovered settings from backup after a settings read error.")
-        merged = DEFAULT_SETTINGS.copy()
+        merged = copy.deepcopy(DEFAULT_SETTINGS)
         merged.update(backup)
         _last_good_settings = copy.deepcopy(merged)
         return merged
 
     log.error("No settings backup available; using defaults (allow-list is disabled).")
-    return DEFAULT_SETTINGS.copy()
+    return copy.deepcopy(DEFAULT_SETTINGS)
 
 
 def _sanitize_dir_list(value):
@@ -139,14 +143,16 @@ def load_settings():
         except OSError as e:
             log.error(f"Could not create settings directory {SETTINGS_DIR}: {e}")
             # Return defaults without attempting to save if dir creation fails
-            return DEFAULT_SETTINGS.copy()
+            return copy.deepcopy(DEFAULT_SETTINGS)
         # Save default settings on first load if file doesn't exist
-        save_settings(DEFAULT_SETTINGS.copy())
-        return DEFAULT_SETTINGS.copy()
+        save_settings(copy.deepcopy(DEFAULT_SETTINGS))
+        return copy.deepcopy(DEFAULT_SETTINGS)
     try:
         with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
             settings = json.load(f)
-    except (json.JSONDecodeError, IOError, OSError) as e:
+        if not isinstance(settings, dict):
+            raise ValueError("settings.json is not a JSON object")
+    except (json.JSONDecodeError, IOError, OSError, ValueError) as e:
         log.error(f"Error loading settings from {SETTINGS_FILE}: {e}. Falling back.")
         return _fallback_settings()
     except Exception as e:

--- a/simkl_mps/players/potplayer.py
+++ b/simkl_mps/players/potplayer.py
@@ -213,9 +213,10 @@ class PotPlayerIntegration:
             
             cleaned_filename = self._clean_filename(clean_title)
             if cleaned_filename:
-                # Match on the raw title: _clean_filename strips leading "[Group]" tags,
-                # but the file on disk keeps them, so the cleaned name wouldn't match.
-                resolved_path = self._resolve_full_path(clean_title, hwnd)
+                # Try the raw title first (keeps "[Group]" tags the real file has), then the
+                # cleaned name (handles title-only appendages like "(With subtitles)").
+                resolved_path = (self._resolve_full_path(clean_title, hwnd)
+                                 or self._resolve_full_path(cleaned_filename, hwnd))
                 if resolved_path:
                     if self.cached_filepath != resolved_path:
                         logger.debug(f"Resolved PotPlayer media to full path: '{resolved_path}'")

--- a/simkl_mps/players/potplayer.py
+++ b/simkl_mps/players/potplayer.py
@@ -271,7 +271,13 @@ class PotPlayerIntegration:
                 if is_video:
                     video_handles.append(candidate_path)
                 if target_basename:
-                    if candidate_basename == target_basename:
+                    target_stem, target_ext = os.path.splitext(target_basename)
+                    # exact match, or stem match when the title hid the extension (video only,
+                    # so we don't grab a same-named .srt)
+                    if candidate_basename == target_basename or (
+                        is_video and not target_ext
+                        and os.path.splitext(candidate_basename)[0] == target_stem
+                    ):
                         return candidate_path
                 elif is_video:
                     return candidate_path

--- a/simkl_mps/players/potplayer.py
+++ b/simkl_mps/players/potplayer.py
@@ -213,7 +213,9 @@ class PotPlayerIntegration:
             
             cleaned_filename = self._clean_filename(clean_title)
             if cleaned_filename:
-                resolved_path = self._resolve_full_path(cleaned_filename, hwnd)
+                # Match on the raw title: _clean_filename strips leading "[Group]" tags,
+                # but the file on disk keeps them, so the cleaned name wouldn't match.
+                resolved_path = self._resolve_full_path(clean_title, hwnd)
                 if resolved_path:
                     if self.cached_filepath != resolved_path:
                         logger.debug(f"Resolved PotPlayer media to full path: '{resolved_path}'")
@@ -258,18 +260,26 @@ class PotPlayerIntegration:
         target_basename = os.path.basename(filename).lower() if filename else None
 
         # Try open file handles first
+        video_handles = []
         try:
             for open_file in process.open_files():
                 candidate_path = open_file.path
                 if not candidate_path:
                     continue
                 candidate_basename = os.path.basename(candidate_path).lower()
+                is_video = os.path.splitext(candidate_basename)[1].lower() in VIDEO_EXTENSIONS
+                if is_video:
+                    video_handles.append(candidate_path)
                 if target_basename:
                     if candidate_basename == target_basename:
                         return candidate_path
-                else:
-                    if os.path.splitext(candidate_basename)[1].lower() in VIDEO_EXTENSIONS:
-                        return candidate_path
+                elif is_video:
+                    return candidate_path
+            # log what was open, for diagnosing resolution failures
+            logger.debug(
+                f"PotPlayer open_files() found no match for '{target_basename}'. "
+                f"Open video files: {video_handles or 'none'}"
+            )
         except Exception as exc:  # pragma: no cover - defensive
             if psutil and isinstance(exc, (psutil.AccessDenied, psutil.NoSuchProcess)):
                 logger.debug(f"Access denied enumerating PotPlayer open files: {exc}")

--- a/simkl_mps/tray_base.py
+++ b/simkl_mps/tray_base.py
@@ -305,7 +305,7 @@ class TrayAppBase(abc.ABC): # Inherit from ABC for abstract methods
 
     def set_allow_dirs(self, _=None):
         current_value = self._format_dir_list_for_dialog(get_setting("allow_dirs", []))
-        help_text = "Enter paths or glob patterns, separated by commas or semicolons."
+        help_text = "Enter folder paths, separated by commas or semicolons. Use * and ? as wildcards; [brackets] in names are matched literally."
         updated_text = self._ask_directory_filter_dialog("Set Allow Directories", current_value, help_text)
         if updated_text is not None:
             entries = self._parse_dir_list_input(updated_text)
@@ -315,7 +315,7 @@ class TrayAppBase(abc.ABC): # Inherit from ABC for abstract methods
 
     def set_deny_dirs(self, _=None):
         current_value = self._format_dir_list_for_dialog(get_setting("deny_dirs", []))
-        help_text = "Enter paths or glob patterns, separated by commas or semicolons."
+        help_text = "Enter folder paths, separated by commas or semicolons. Use * and ? as wildcards; [brackets] in names are matched literally."
         updated_text = self._ask_directory_filter_dialog("Set Deny Directories", current_value, help_text)
         if updated_text is not None:
             entries = self._parse_dir_list_input(updated_text)

--- a/simkl_mps/utils/path_filter.py
+++ b/simkl_mps/utils/path_filter.py
@@ -19,12 +19,16 @@ def _is_case_sensitive_filesystem() -> bool:
 
 
 def _normalize_path(path_value: str, case_sensitive: bool) -> str:
-    """Normalize a path for reliable comparisons."""
-    try:
-        resolved = Path(path_value).expanduser().resolve(strict=False)
-    except Exception:
-        resolved = Path(path_value).expanduser().absolute()
-    normalized = os.path.normpath(str(resolved))
+    """Normalize for comparison; relative paths aren't resolved against the CWD."""
+    expanded = os.path.expanduser(path_value)
+    if os.path.isabs(expanded):
+        try:
+            resolved = str(Path(expanded).resolve(strict=False))
+        except Exception:
+            resolved = os.path.abspath(expanded)
+        normalized = os.path.normpath(resolved)
+    else:
+        normalized = os.path.normpath(expanded)
     return normalized if case_sensitive else normalized.lower()
 
 
@@ -60,8 +64,23 @@ def _coerce_string_list(values: Optional[Iterable[str]]) -> List[str]:
     return [value for value in values if isinstance(value, str) and value.strip()]
 
 
-def _contains_glob(pattern_value: str) -> bool:
-    return any(char in pattern_value for char in ("*", "?", "[", "]"))
+def _contains_wildcard(pattern_value: str) -> bool:
+    """True for a real glob wildcard. '[' and ']' don't count -- folders like
+    '[SubsPlease]' would otherwise be read as fnmatch character classes."""
+    return "*" in pattern_value or "?" in pattern_value
+
+
+def _escape_literal_brackets(pattern_value: str) -> str:
+    """Escape '[' and ']' for fnmatch so bracketed folder names match literally."""
+    escaped_chars = []
+    for char in pattern_value:
+        if char == "[":
+            escaped_chars.append("[[]")
+        elif char == "]":
+            escaped_chars.append("[]]")
+        else:
+            escaped_chars.append(char)
+    return "".join(escaped_chars)
 
 
 def _normalize_for_match(path_value: str) -> str:
@@ -80,13 +99,14 @@ def _match_rule(file_path: str, rule: str, case_sensitive: bool) -> bool:
     normalized_file = _normalize_for_match(file_path)
     normalized_rule = _normalize_for_match(rule)
 
-    if _contains_glob(normalized_rule) or not os.path.isabs(normalized_rule):
-        # Treat relative patterns as match-anywhere
+    if _contains_wildcard(normalized_rule) or not os.path.isabs(normalized_rule):
+        # relative patterns match anywhere
         if not os.path.isabs(normalized_rule) and not normalized_rule.startswith("**"):
             normalized_rule = os.path.join("**", normalized_rule)
-        return fnmatch.fnmatchcase(normalized_file, normalized_rule)
+        pattern = _escape_literal_brackets(normalized_rule)
+        return fnmatch.fnmatchcase(normalized_file, pattern)
 
-    # Non-glob absolute rule: directory prefix match
+    # plain absolute dir: prefix match by path parts
     return _is_path_within_directory(normalized_file, normalized_rule)
 
 

--- a/test_path_filter.py
+++ b/test_path_filter.py
@@ -1,0 +1,214 @@
+"""Regression tests for the allow/deny directory filter (path_filter.py) and its settings
+file (config_manager.py): bracket folders, empty-list leak, CWD-relative paths.
+Run with pytest or `python3 test_path_filter.py`."""
+
+import json
+import os
+import sys
+import tempfile
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+# Load these two stdlib-only modules straight from disk; importing the full package would
+# run app startup and touch the real settings.json.
+import importlib.util
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_HERE, relpath))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+path_filter = _load("path_filter", os.path.join("simkl_mps", "utils", "path_filter.py"))
+config_manager = _load("config_manager", os.path.join("simkl_mps", "config_manager.py"))
+is_path_allowed = path_filter.is_path_allowed
+
+# Absolute paths valid on the host OS; lowercase to dodge case-insensitivity surprises.
+_ROOT = "c:\\" if os.name == "nt" else "/"
+
+
+def P(*parts):
+    """Absolute, host-appropriate path from lowercase components."""
+    return os.path.join(_ROOT, *parts)
+
+
+# --- bracket folders ---
+
+def test_bracket_folder_as_allow_rule_allows_its_files():
+    rule = P("downloads", "[subsplease] show")
+    f = P("downloads", "[subsplease] show", "ep01.mkv")
+    assert is_path_allowed(f, allow_dirs=[rule]) is True
+
+
+def test_bracket_folder_as_deny_rule_blocks_its_files():
+    rule = P("downloads", "[subsplease]")
+    f = P("downloads", "[subsplease]", "ep01.mkv")
+    assert is_path_allowed(f, allow_dirs=[], deny_dirs=[rule]) is False
+
+
+def test_bracket_file_allowed_under_wildcard_rule():
+    # Brackets on the file side already worked; keep it that way.
+    rule = P("downloads") + os.sep + "**"
+    f = P("downloads", "[judas] movie (2021)", "movie.mkv")
+    assert is_path_allowed(f, allow_dirs=[rule]) is True
+
+
+def test_wildcard_rule_containing_brackets_matches_nested_files():
+    rule = P("downloads", "[judas] movies") + os.sep + "**"
+    f = P("downloads", "[judas] movies", "film", "movie.mkv")
+    assert is_path_allowed(f, allow_dirs=[rule]) is True
+
+
+def test_bracket_rule_does_not_spuriously_match_single_char_sibling():
+    # Old bug: "[subsplease]" matched any single character at that spot.
+    rule = P("downloads", "[subsplease]")
+    impostor = P("downloads", "s", "ep01.mkv")
+    assert is_path_allowed(impostor, allow_dirs=[rule]) is False
+
+
+# --- path normalization + scoping ---
+
+def test_relative_path_not_cwd_prefixed():
+    # This used to come back as an absolute, CWD-joined path.
+    norm = path_filter._normalize_path("bare.mkv", case_sensitive=True)
+    assert not os.path.isabs(norm)
+    assert "bare.mkv" in norm
+
+
+def test_bare_filename_denied_under_nonempty_allowlist():
+    # Can't tell where a bare filename lives, so a whitelist should reject it.
+    assert is_path_allowed("some.movie.mkv", allow_dirs=[P("downloads")]) is False
+
+
+def test_allowlist_scopes_to_folder_and_blocks_elsewhere():
+    allow = [P("downloads") + os.sep + "**", P("downloads")]
+    assert is_path_allowed(P("downloads", "show", "ep.mkv"), allow_dirs=allow) is True
+    assert is_path_allowed(P("downloads", "ep.mkv"), allow_dirs=allow) is True
+    assert is_path_allowed(P("movies", "other.mkv"), allow_dirs=allow) is False
+    assert is_path_allowed(P("downloads2", "other.mkv"), allow_dirs=allow) is False
+
+
+def test_empty_allowlist_allows_everything_by_design():
+    # Empty allow-list = no filter configured, so everything passes.
+    assert is_path_allowed(P("anywhere", "x.mkv"), allow_dirs=[]) is True
+    assert is_path_allowed(P("anywhere", "x.mkv"), allow_dirs=None) is True
+
+
+# --- settings persistence never drops the allow-list ---
+
+class _TempSettings:
+    """Point config_manager at a throwaway settings.json for the duration of a test."""
+
+    def __enter__(self):
+        self._dir = tempfile.mkdtemp(prefix="mps-cfg-")
+        self._saved = (config_manager.SETTINGS_DIR, config_manager.SETTINGS_FILE,
+                       config_manager._last_good_settings)
+        from pathlib import Path
+        config_manager.SETTINGS_DIR = Path(self._dir)
+        config_manager.SETTINGS_FILE = Path(self._dir) / "settings.json"
+        config_manager._last_good_settings = None
+        return self
+
+    def __exit__(self, *exc):
+        (config_manager.SETTINGS_DIR, config_manager.SETTINGS_FILE,
+         config_manager._last_good_settings) = self._saved
+        import shutil
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+
+def test_save_is_atomic_valid_json():
+    with _TempSettings():
+        config_manager.save_settings({"allow_dirs": [P("downloads")], "deny_dirs": []})
+        with open(config_manager.SETTINGS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)  # raises if not valid JSON
+        assert data["allow_dirs"] == [P("downloads")]
+        # No leftover temp file.
+        assert not (config_manager.SETTINGS_FILE.parent /
+                    (config_manager.SETTINGS_FILE.name + ".tmp")).exists()
+
+
+def test_corrupt_file_falls_back_to_last_good_allowlist():
+    with _TempSettings():
+        good = {**config_manager.DEFAULT_SETTINGS, "allow_dirs": [P("downloads")]}
+        config_manager.save_settings(good)
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+        # Corrupt it, like a half-finished write would.
+        with open(config_manager.SETTINGS_FILE, "w", encoding="utf-8") as f:
+            f.write("{ this is not valid json ")
+
+        # Must not come back empty; that would kill the whitelist.
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+
+def test_backup_recovers_allowlist_after_restart():
+    # Fresh process (no in-memory cache) + corrupt settings.json must still recover
+    # the allow-list from the .bak file, not fall back to "allow everything".
+    with _TempSettings():
+        config_manager.save_settings({**config_manager.DEFAULT_SETTINGS,
+                                      "allow_dirs": [P("downloads")]})
+        config_manager._last_good_settings = None  # simulate a restart
+        with open(config_manager.SETTINGS_FILE, "w", encoding="utf-8") as f:
+            f.write("{ half-written")
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+
+def test_save_retries_transient_replace_failure():
+    # A one-off os.replace failure (Windows sharing violation) should be retried, not
+    # swallowed, so the save still lands.
+    with _TempSettings():
+        real_replace = os.replace
+        calls = {"n": 0}
+
+        def flaky_replace(src, dst):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PermissionError("simulated WinError 5")
+            return real_replace(src, dst)
+
+        config_manager.os.replace = flaky_replace
+        try:
+            ok = config_manager.save_settings({**config_manager.DEFAULT_SETTINGS,
+                                               "allow_dirs": [P("downloads")]})
+        finally:
+            config_manager.os.replace = real_replace
+        assert ok is True
+        assert calls["n"] >= 2  # first attempt failed, retry succeeded
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+
+def test_load_persists_enrichment_to_disk():
+    # A settings file missing default keys gets enriched, and load_settings must write that
+    # back. The save has to run AFTER the read handle is closed -- doing it while the file
+    # was still open failed on Windows (rename-over-open, WinError 5), so the enrichment
+    # never reached disk. This asserts it does.
+    with _TempSettings():
+        with open(config_manager.SETTINGS_FILE, "w", encoding="utf-8") as fh:
+            json.dump({"watch_completion_threshold": 80}, fh)  # missing allow_dirs/deny_dirs/...
+        settings = config_manager.load_settings()
+        assert "allow_dirs" in settings and "deny_dirs" in settings
+        with open(config_manager.SETTINGS_FILE, "r", encoding="utf-8") as fh:
+            on_disk = json.load(fh)
+        assert "allow_dirs" in on_disk  # enrichment actually persisted
+
+
+def _run_standalone():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    failures = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception as e:  # noqa: BLE001 - test runner surfaces any failure
+            failures += 1
+            print(f"FAIL  {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failures}/{len(fns)} passed")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_standalone() else 0)

--- a/test_path_filter.py
+++ b/test_path_filter.py
@@ -195,6 +195,46 @@ def test_load_persists_enrichment_to_disk():
         assert "allow_dirs" in on_disk  # enrichment actually persisted
 
 
+def test_non_dict_settings_json_falls_back():
+    # settings.json holding valid-but-non-dict JSON must not crash the load.
+    with _TempSettings():
+        config_manager.save_settings({**config_manager.DEFAULT_SETTINGS, "allow_dirs": [P("downloads")]})
+        with open(config_manager.SETTINGS_FILE, "w", encoding="utf-8") as f:
+            f.write("[1, 2, 3]")
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+
+def test_non_dict_backup_ignored():
+    with _TempSettings():
+        with open(config_manager._backup_path(), "w", encoding="utf-8") as f:
+            f.write('"not a dict"')
+        assert config_manager._load_backup() is None
+
+
+def test_defaults_not_mutated_by_returned_settings():
+    with _TempSettings():
+        config_manager._last_good_settings = None  # no cache, no backup -> returns defaults
+        settings = config_manager._fallback_settings()
+        settings["allow_dirs"].append("x")
+        assert config_manager.DEFAULT_SETTINGS["allow_dirs"] == []
+
+
+def test_save_survives_fsync_failure():
+    with _TempSettings():
+        real_fsync = os.fsync
+
+        def boom(fd):
+            raise OSError("fsync unsupported")
+
+        config_manager.os.fsync = boom
+        try:
+            ok = config_manager.save_settings({**config_manager.DEFAULT_SETTINGS, "allow_dirs": [P("downloads")]})
+        finally:
+            config_manager.os.fsync = real_fsync
+        assert ok is True
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+
+
 def _run_standalone():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/test_path_filter.py
+++ b/test_path_filter.py
@@ -235,6 +235,14 @@ def test_save_survives_fsync_failure():
         assert config_manager.get_setting("allow_dirs") == [P("downloads")]
 
 
+def test_save_sanitizes_dir_lists():
+    # junk/missing dir lists get cleaned before write + cache, so a later fallback is safe.
+    with _TempSettings():
+        config_manager.save_settings({"allow_dirs": ["  ", 123, P("downloads")]})
+        assert config_manager.get_setting("allow_dirs") == [P("downloads")]
+        assert config_manager.get_setting("deny_dirs") == []
+
+
 def _run_standalone():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/test_path_filter.py
+++ b/test_path_filter.py
@@ -24,6 +24,7 @@ def _load(name, relpath):
 
 path_filter = _load("path_filter", os.path.join("simkl_mps", "utils", "path_filter.py"))
 config_manager = _load("config_manager", os.path.join("simkl_mps", "config_manager.py"))
+potplayer = _load("potplayer", os.path.join("simkl_mps", "players", "potplayer.py"))
 is_path_allowed = path_filter.is_path_allowed
 
 # Absolute paths valid on the host OS; lowercase to dodge case-insensitivity surprises.
@@ -241,6 +242,50 @@ def test_save_sanitizes_dir_lists():
         config_manager.save_settings({"allow_dirs": ["  ", 123, P("downloads")]})
         assert config_manager.get_setting("allow_dirs") == [P("downloads")]
         assert config_manager.get_setting("deny_dirs") == []
+
+
+# --- PotPlayer full-path resolution (forward slashes so os.path.basename splits on any OS) ---
+
+class _FakeOpenFile:
+    def __init__(self, path):
+        self.path = path
+
+
+class _FakeProc:
+    def __init__(self, paths):
+        self._paths = paths
+
+    def open_files(self):
+        return [_FakeOpenFile(p) for p in self._paths]
+
+    def cmdline(self):
+        return []
+
+
+def _potplayer_with_open_files(paths):
+    integ = potplayer.PotPlayerIntegration()
+    integ._get_process_from_hwnd = lambda hwnd: _FakeProc(paths)
+    return integ
+
+
+def test_potplayer_resolves_group_tagged_file():
+    # Raw title (with the [Group] tag the real file has) resolves; the cleaned name doesn't.
+    integ = _potplayer_with_open_files(["D:/downloads/[Erai-raws] Baki-dou - 15.mkv"])
+    assert integ._resolve_full_path("[Erai-raws] Baki-dou - 15.mkv", 1) == "D:/downloads/[Erai-raws] Baki-dou - 15.mkv"
+    assert integ._resolve_full_path("Baki-dou - 15.mkv", 1) is None
+
+
+def test_potplayer_falls_back_to_cleaned_name():
+    # File on disk has no appendage; the cleaned name matches, the raw title doesn't.
+    integ = _potplayer_with_open_files(["D:/movies/Show.mkv"])
+    assert integ._resolve_full_path("Show (With subtitles).mkv", 1) is None
+    assert integ._resolve_full_path("Show.mkv", 1) == "D:/movies/Show.mkv"
+
+
+def test_potplayer_hidden_extension_prefers_video_not_subtitle():
+    # Title hid the extension -> stem match, but must pick the video, not a same-named .srt.
+    integ = _potplayer_with_open_files(["D:/dl/Show.srt", "D:/dl/Show.mkv"])
+    assert integ._resolve_full_path("Show", 1) == "D:/dl/Show.mkv"
 
 
 def _run_standalone():


### PR DESCRIPTION
Bracket folders matched literally, atomic settings with .bak recovery, and PotPlayer full-path resolution; adds tests

Fixed detecting folders with brackets in name "[]", it treated them as wildcards. 
When settings file was locked, it went to empty settings so it allowed everything even if you had specific allow dir or deny dirs. My fix writes to a temp file then swapped in and a bak copy made as backup justtt to be sure. 

On windows it was spamming WinError 5 because it couldn't save the settings file because it was trying to overwrite the settings file while it was open for reading. Now it will save after closing.

Most importantly, it reads full path by matching actual file name so the folderfilter can see where the file actually lives. 
and tests added too :)

Tested and works. 